### PR TITLE
feat: truly clone fish inline prompt update behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ xontrib load hist_navigator
 
 | command | description                                                        | shortcut          |
 | ------- | ------------------------------------------------------------------ | ----------------- |
-| nextd   | move to previous working directory                                 | Alt + Left Arrow  |
-| prevd   | move to next working directory in the history (if `prevd` is used) | Alt + Right Arrow |
+| prevd   | move to previous working directory                                 | Alt + Left Arrow  |
+| nextd   | move to next working directory in the history (if `prevd` is used) | Alt + Right Arrow |
 | listd   | list cd history                                                    |                   |
 | cd ..   | move to parent directory                                           | Alt + Up Arrow    |
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ xontribs = [ "hist_navigator", # Initializes hist_navigator (fish-shell-like dir
 # ↓ optional configuration variables (use `False` to disable a keybind)
 if 'hist_navigator' in xontribs: # configure xontrib only if it's loaded
   # config var                 value  |default|alt_cmd¦ comment
-  envx["X_HISTNAV_KEY_PREV"] = "⎇←"  #|['escape','left' ]|False¦ Move to the previous working directory
-  envx["X_HISTNAV_KEY_NEXT"] = "⎇→"  #|['escape','right']|False¦ Move to the next working directory in the history (if 'prevd' was used)
-  envx["X_HISTNAV_KEY_UP"]   = "⎇↑"  #|['escape','up'   ]|False¦ Move to the parent directory
+  envx["XSH_HISTNAV_KEY_PREV"] = "⎇←"  #|['escape','left' ]|False¦ Move to the previous working directory
+  envx["XSH_HISTNAV_KEY_NEXT"] = "⎇→"  #|['escape','right']|False¦ Move to the next working directory in the history (if 'prevd' was used)
+  envx["XSH_HISTNAV_KEY_UP"]   = "⎇↑"  #|['escape','up'   ]|False¦ Move to the parent directory
   # run to see the allowed list for ↑: from prompt_toolkit.keys import ALL_KEYS; print(ALL_KEYS)
   # Alt is also supported as either of: a- ⎇ ⌥ (converted to a prefix 'escape')
   # Control symbols are also supported as either of: ⎈ ⌃
   # Arrow key symbols are also supported as either of: ▼▲◀▶ ↓↑←→
-  envx["X_HISTNAV_EMPTY_PROMPT"] = False #|True|False¦ Keybinds only work in an empty prompt
+  envx["XSH_HISTNAV_EMPTY_PROMPT"] = False #|True|False¦ Keybinds only work in an empty prompt
 
 xontribs_load(xontribs) # actually load all xontribs in the list
 ```
@@ -51,7 +51,7 @@ xontribs_load(xontribs) # actually load all xontribs in the list
 ```xsh
 xontrib load hist_navigator
 # configure like in the example above, but replace envx['VAR'] with $VAR
-$X_HISTNAV_KEY_PREV	= "⎇←" # ...
+$XSH_HISTNAV_KEY_PREV	= "⎇←" # ...
 ```
 
 # Overview

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fish-shell like `prevd` and `nextd` for [xonsh](https://github.com/xonsh/xonsh/) with keyboard shortcuts
 
-# Usage
+# Installation
 
 - install using pip
 ```sh
@@ -19,6 +19,39 @@ xpip install xontrib-hist-navigator
 
 ```sh
 xontrib load hist_navigator
+```
+
+# Usage
+
+1. Add the following to your `.py` xontrib loading config and `import` it in your xonsh run control file (`~/.xonshrc` or `~/.config/rc.xsh`):
+```py
+from xonsh.xontribs 	import xontribs_load
+from xonsh.built_ins	import XSH
+envx = XSH.env
+
+xontribs = [ "hist_navigator", # Initializes hist_navigator (fish-shell-like dir history navigation)
+ # your other xontribs
+]
+# ↓ optional configuration variables (use `False` to disable a keybind)
+if 'hist_navigator' in xontribs: # configure xontrib only if it's loaded
+  # config var                 value  |default|alt_cmd¦ comment
+  envx["X_HISTNAV_KEY_PREV"] = "⎇←"  #|['escape','left' ]|False¦ Move to the previous working directory
+  envx["X_HISTNAV_KEY_NEXT"] = "⎇→"  #|['escape','right']|False¦ Move to the next working directory in the history (if 'prevd' was used)
+  envx["X_HISTNAV_KEY_UP"]   = "⎇↑"  #|['escape','up'   ]|False¦ Move to the parent directory
+  # run to see the allowed list for ↑: from prompt_toolkit.keys import ALL_KEYS; print(ALL_KEYS)
+  # Alt is also supported as either of: a- ⎇ ⌥ (converted to a prefix 'escape')
+  # Control symbols are also supported as either of: ⎈ ⌃
+  # Arrow key symbols are also supported as either of: ▼▲◀▶ ↓↑←→
+  envx["X_HISTNAV_EMPTY_PROMPT"] = False #|True|False¦ Keybinds only work in an empty prompt
+
+xontribs_load(xontribs) # actually load all xontribs in the list
+```
+
+2. Or just add this to your xonsh run control file
+```xsh
+xontrib load hist_navigator
+# configure like in the example above, but replace envx['VAR'] with $VAR
+$X_HISTNAV_KEY_PREV	= "⎇←" # ...
 ```
 
 # Overview

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -85,6 +85,11 @@ def cmd_empty_prompt():
     )
 
 
+@Condition
+def key_always():
+    """Always activate key binding"""
+    return True
+
 def insert_text(event, text):
     from xonsh.ptk_shell.key_bindings import carriage_return
 
@@ -158,17 +163,22 @@ def custom_keybindings(bindings, **_):
             else:
                 return bind_add( key_def, filter=filter)
 
-    @handler("X_HISTNAV_KEY_PREV", filter=cmd_empty_prompt)
+    if envx.get("X_HISTNAV_EMPTY_PROMPT", ""):
+        _filter = cmd_empty_prompt
+    else:
+        _filter = key_always
+
+    @handler("X_HISTNAV_KEY_PREV", filter=_filter)
     def bind_prevd(event):
         """Equivalent to typing `prevd<enter>`"""
         insert_text(event, "prevd")
 
-    @handler("X_HISTNAV_KEY_NEXT", filter=cmd_empty_prompt)
+    @handler("X_HISTNAV_KEY_NEXT", filter=_filter)
     def bind_nextd(event):
         """Equivalent to typing `nextd<enter>`"""
         insert_text(event, "nextd")
 
-    @handler("X_HISTNAV_KEY_UP", filter=cmd_empty_prompt)
+    @handler("X_HISTNAV_KEY_UP", filter=_filter)
     def execute_version(event):
         """cd to parent directory"""
         insert_text(event, "cd ..")

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -191,24 +191,17 @@ def custom_keybindings(bindings, **_):
         "XSH_HISTNAV_KEY_UP"   : ['escape','up'   ],
     }
 
-    is_ptk = _is_ptk()
-
     def handler(key_user_var, filter):
         def skip(func):
           pass
-
-        if is_ptk:
-            bind_add = bindings.add
-        else:
-            bind_add = bindings.registry.add_binding
 
         key_user = envx.get(     key_user_var, None)
         key_def  = _default_keys[key_user_var]
         if   key_user is None:     # doesn't exist       → use default
             if type(key_def) == list:
-                return bind_add(*key_def, filter=filter)
+                return bindings.add(*key_def, filter=filter)
             else:
-                return bind_add( key_def, filter=filter)
+                return bindings.add( key_def, filter=filter)
         elif key_user is False:    # exists and disabled → don't bind
             return skip
         elif type(key_user) == str:# remove whitespace
@@ -218,10 +211,10 @@ def custom_keybindings(bindings, **_):
 
         if   type(key_user) == str  and\
              key_user in ALL_KEYS: # exists and   valid  → use it
-            return bind_add(key_user, filter=filter)
+            return bindings.add(key_user, filter=filter)
         elif type(key_user) == list and\
             all(k in ALL_KEYS or _parse_key(k) for k in key_user):
-            return bind_add(*key_user, filter=filter)
+            return bindings.add(*key_user, filter=filter)
         else:                      # exists and invalid  → use default
             print_color("{BLUE}xontrib-hist_navigator:{RESET} your "+\
                 key_user_var+" '{BLUE}"+str(key_user)+\
@@ -230,45 +223,29 @@ def custom_keybindings(bindings, **_):
               "{RESET}'; run ↓ to see the allowed list\n"+\
               "from prompt_toolkit.keys import ALL_KEYS; print(ALL_KEYS)")
             if type(key_def) == list:
-                return bind_add(*key_def, filter=filter)
+                return bindings.add(*key_def, filter=filter)
             else:
-                return bind_add( key_def, filter=filter)
+                return bindings.add( key_def, filter=filter)
 
     if envx.get("XSH_HISTNAV_EMPTY_PROMPT", ""):
         _filter = cmd_empty_prompt
     else:
         _filter = key_always
 
-    if is_ptk:
-        @handler("XSH_HISTNAV_KEY_PREV", filter=_filter)
-        def bind_prevd(event):
-            """cd to `prevd`"""
-            prevd()
+    @handler("XSH_HISTNAV_KEY_PREV", filter=_filter)
+    def bind_prevd(event):
+        """cd to `prevd`"""
+        prevd()
 
-        @handler("XSH_HISTNAV_KEY_NEXT", filter=_filter)
-        def bind_nextd(event):
-            """cd to `nextd`"""
-            nextd()
+    @handler("XSH_HISTNAV_KEY_NEXT", filter=_filter)
+    def bind_nextd(event):
+        """cd to `nextd`"""
+        nextd()
 
-        @handler("XSH_HISTNAV_KEY_UP", filter=_filter)
-        def execute_version(event):
-            """cd to parent directory"""
-            _cd_inline('..')
-    else:
-        @handler("XSH_HISTNAV_KEY_PREV", filter=_filter)
-        def bind_prevd(event):
-            """Type `prevd⏎`"""
-            insert_text(event, "prevd")
-
-        @handler("XSH_HISTNAV_KEY_NEXT", filter=_filter)
-        def bind_nextd(event):
-            """Type `nextd⏎`"""
-            insert_text(event, "nextd")
-
-        @handler("XSH_HISTNAV_KEY_UP", filter=_filter)
-        def execute_version(event):
-            """Type `cd ..`"""
-            insert_text(event, "cd ..")
+    @handler("XSH_HISTNAV_KEY_UP", filter=_filter)
+    def execute_version(event):
+        """cd to parent directory"""
+        _cd_inline('..')
 
 
 __all__ = ("XSH_DIRS_HISTORY",)

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -85,6 +85,13 @@ def listd():
     print(XSH_DIRS_HISTORY.history)
 
 
+def _is_ptk():
+    if envx.get('SHELL_TYPE') in ["prompt_toolkit", "prompt_toolkit2"]:
+        return True
+    else:
+        return False
+
+
 def _p_msg_fmt(s):
     return tokenize_ansi(PygmentsTokens(partial_color_tokenize(XSH.shell.shell.prompt_formatter(s)))) # noqa
 

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -159,6 +159,26 @@ def _cd_inline(path: typing.Optional[typing.AnyStr] = None) -> None:
         t.start()
 
 
+def _parse_key_user(key_user):
+    _key_symb = {
+        '⎈':'c-'  ,'⌃':'c-'   ,
+        '▼':'down' ,'↓':'down' ,
+        '▲':'up'   ,'↑':'up'   ,
+        '◀':'left' ,'←':'left' ,
+        '▶':'right','→':'right',
+    }
+    _alts = ['a-','⌥','⎇']
+
+    for k,v in _key_symb.items(): # replace symbols
+        if k in key_user: # replace other keys
+            key_user = key_user.replace(k,v)
+    for alt in _alts:
+        if alt in key_user: # replace alt with an ⎋ sequence of keys
+            key_user = ['escape', key_user.replace(alt,'')]
+            break
+
+    return key_user
+
 @XSH.builtins.events.on_ptk_create  # noqa
 def custom_keybindings(bindings, **_):
     from prompt_toolkit.key_binding.key_bindings import _parse_key
@@ -170,15 +190,6 @@ def custom_keybindings(bindings, **_):
         "XSH_HISTNAV_KEY_NEXT" : ['escape','right'],
         "XSH_HISTNAV_KEY_UP"   : ['escape','up'   ],
     }
-
-    _key_symb = {
-        '⎈':'c-'  ,'⌃':'c-'   ,
-        '▼':'down' ,'↓':'down' ,
-        '▲':'up'   ,'↑':'up'   ,
-        '◀':'left' ,'←':'left' ,
-        '▶':'right','→':'right',
-    }
-    _alts = ['a-','⌥','⎇']
 
     is_ptk = _is_ptk()
 
@@ -203,14 +214,7 @@ def custom_keybindings(bindings, **_):
         elif type(key_user) == str:# remove whitespace
             key_user = re_despace.sub('',key_user)
 
-        for k,v in _key_symb.items(): # replace symbols
-            if k in key_user: # replace other keys
-                key_user = key_user.replace(k,v)
-                break
-        for alt in _alts:
-            if alt in key_user: # replace alt with an ⎋ sequence of keys
-                key_user = ['escape', key_user.replace(alt,'')]
-                break
+        key_user = _parse_key_user(key_user)
 
         if   type(key_user) == str  and\
              key_user in ALL_KEYS: # exists and   valid  → use it

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -153,9 +153,9 @@ def custom_keybindings(bindings, **_):
     re_despace = re.compile(r'\s', re.IGNORECASE)
 
     _default_keys = {
-        "X_HISTNAV_KEY_PREV" : ['escape','left' ],
-        "X_HISTNAV_KEY_NEXT" : ['escape','right'],
-        "X_HISTNAV_KEY_UP"   : ['escape','up'   ],
+        "XSH_HISTNAV_KEY_PREV" : ['escape','left' ],
+        "XSH_HISTNAV_KEY_NEXT" : ['escape','right'],
+        "XSH_HISTNAV_KEY_UP"   : ['escape','up'   ],
     }
 
     _key_symb = {
@@ -215,22 +215,22 @@ def custom_keybindings(bindings, **_):
             else:
                 return bind_add( key_def, filter=filter)
 
-    if envx.get("X_HISTNAV_EMPTY_PROMPT", ""):
+    if envx.get("XSH_HISTNAV_EMPTY_PROMPT", ""):
         _filter = cmd_empty_prompt
     else:
         _filter = key_always
 
-    @handler("X_HISTNAV_KEY_PREV", filter=_filter)
+    @handler("XSH_HISTNAV_KEY_PREV", filter=_filter)
     def bind_prevd(event):
         """cd to `prevd`"""
         prevd()
 
-    @handler("X_HISTNAV_KEY_NEXT", filter=_filter)
+    @handler("XSH_HISTNAV_KEY_NEXT", filter=_filter)
     def bind_nextd(event):
         """cd to `nextd`"""
         nextd()
 
-    @handler("X_HISTNAV_KEY_UP", filter=_filter)
+    @handler("XSH_HISTNAV_KEY_UP", filter=_filter)
     def execute_version(event):
         """cd to parent directory"""
         _cd_inline('..')

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -38,7 +38,7 @@ class _DirsHistory:
         if self.history:
             self.moved = True
             item = self.history[self.cursor]
-            XSH.subproc_captured_stdout(["cd", item])
+            _cd_inline(item)
             self.moved = False
 
     def __repr__(self):
@@ -215,13 +215,13 @@ def custom_keybindings(bindings, **_):
 
     @handler("X_HISTNAV_KEY_PREV", filter=_filter)
     def bind_prevd(event):
-        """Equivalent to typing `prevd<enter>`"""
-        insert_text(event, "prevd")
+        """cd to `prevd`"""
+        prevd()
 
     @handler("X_HISTNAV_KEY_NEXT", filter=_filter)
     def bind_nextd(event):
-        """Equivalent to typing `nextd<enter>`"""
-        insert_text(event, "nextd")
+        """cd to `nextd`"""
+        nextd()
 
     @handler("X_HISTNAV_KEY_UP", filter=_filter)
     def execute_version(event):


### PR DESCRIPTION
Adds the following features:
  - move dir up/prev/next without creating a new prompt, updating exisiting one (just like in fish) instead of having to simulate typing and entering a command
  - use keybinds in non-empty prompts (optional, disabled by default, maybe with the default arrow keybinds it's fine having it disabled not to interfere with word movements, but if you rebind to somethinkg vim-like home row keys then it's great to cd without having to clear your commands)
  - customize keybinds via environment variables with some nice parsing options like being able to bind Alt directly and also the proper ⎇ symbol
