### PR TITLE
Make history traversal more intuitive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: "23.1.0"
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.11
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.1.1" # Use the sha / tag you want to point at

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
     "files.associations": {
         "*.xsh": "python"
-    },
-    "python.formatting.provider": "yapf"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -28,10 +28,106 @@ xontrib load hist_navigator
 
 | command | description                                                        | shortcut          |
 | ------- | ------------------------------------------------------------------ | ----------------- |
-| nextd   | move to previous working directory                                 | Alt + Left Arrow  |
-| prevd   | move to next working directory in the history (if `prevd` is used) | Alt + Right Arrow |
+| prevd   | move to previous working directory                                 | Alt + Left Arrow  |
+| nextd   | move to next working directory in the history (if `prevd` is used) | Alt + Right Arrow |
 | listd   | list cd history                                                    |                   |
 | cd ..   | move to parent directory                                           | Alt + Up Arrow    |
+
+
+# Traversal behavior
+
+By default, all cd history is kept. Let's look at an example. Let's open
+a new shell:
+
+```sh
+❯
+```
+
+Now when we change the directory, it's added to the history along with
+the previous directory where we were (the user's home directory):
+
+```sh
+❯ cd BASE
+❯ listd
+['~', '~/BASE']
+```
+
+Let's descend further down:
+
+```sh
+❯ cd sub
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+```
+
+So far, so obvious. Now, when we use `prevd`, you'll see that the history
+stays intact:
+
+```sh
+❯ prevd
+❯ pwd
+~/BASE
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+```
+
+This allows you to use `nextd` to go back and forth:
+
+```sh
+❯ nextd
+❯ pwd
+~/BASE/sub
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+❯ prevd
+❯ pwd
+~/BASE
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+```
+
+Now, if you change the directory entirely after a `prevd`, the entire
+previous history is still kept:
+
+```sh
+❯ pwd
+~/BASE
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+❯ cd /tmp
+❯ listd
+['~', '~/BASE', '~/BASE/sub', '/tmp']
+```
+
+This means that issuing `prevd` now will actually return to `~/BASE/sub`
+and not to `~/BASE` which was the last seen previous directory.
+This is by design to allow you to quickly traverse previously visited
+directories using keyboard shortcuts.
+
+If you would rather have the history truncated, so that `prevd` always
+takes you to the directory you were in just before, set the following
+environment variable in your xonshrc:
+
+```xsh
+$XONTRIB_HIST_NAVIGATOR_TRUNCATE="true"
+```
+
+In this case the last example would behave differently:
+
+```sh
+❯ pwd
+~/BASE
+❯ listd
+['~', '~/BASE', '~/BASE/sub']
+❯ cd /tmp
+❯ listd
+['~', '~/BASE', '/tmp']
+```
+
+As you can see `~/BASE/sub` was dropped from history because it wasn't
+the last visited directory at the time of changing the directory to
+`/tmp`.
+
 
 # Release
 

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -13,19 +13,33 @@ class _DirsHistory:
             return  # do not add same item twice in the stack
         self.history.append(item)
 
+    @property
+    def cursor_left(self):
+        return max(self.cursor - 1, 0)
+
+    @property
+    def cursor_right(self):
+        return min(self.cursor + 1, len(self.history) - 1)
+
     def add(self, old: str, new: str):
         if not self.moved:
             if not self.history:
                 self._append(old)
+            else:
+                if new == self.history[self.cursor_left]:
+                    return self.prev()
+                if new == self.history[self.cursor_right]:
+                    return self.next()
+                self.history = self.history[:self.cursor+1]
             self._append(new)
             self.cursor = len(self.history) - 1
 
     def prev(self):
-        self.cursor = max(self.cursor - 1, 0)
+        self.cursor = self.cursor_left
         self._move()
 
     def next(self):
-        self.cursor = min(self.cursor + 1, len(self.history) - 1)
+        self.cursor = self.cursor_right
         self._move()
 
     def _move(self):

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -37,9 +37,9 @@ class _DirsHistory:
                 if new == self.history[self.cursor_right]:
                     return self.next()
 
-                should_truncate = XSH.env.get('XONTRIB_HIST_NAVIGATOR_TRUNCATE', '0')
+                should_truncate = XSH.env.get("XONTRIB_HIST_NAVIGATOR_TRUNCATE", "0")
                 if is_truthy(should_truncate):
-                    self.history = self.history[:self.cursor+1]
+                    self.history = self.history[: self.cursor + 1]
             self._append(new)
             self.cursor = len(self.history) - 1
 

--- a/xontrib/hist_navigator.py
+++ b/xontrib/hist_navigator.py
@@ -1,5 +1,11 @@
+from configparser import ConfigParser
+
 from prompt_toolkit.filters import Condition
 from xonsh.built_ins import XSH
+
+
+def is_truthy(s: str) -> bool:
+    return ConfigParser.BOOLEAN_STATES.get(s.lower(), False)
 
 
 class _DirsHistory:
@@ -30,7 +36,10 @@ class _DirsHistory:
                     return self.prev()
                 if new == self.history[self.cursor_right]:
                     return self.next()
-                self.history = self.history[:self.cursor+1]
+
+                should_truncate = XSH.env.get('XONTRIB_HIST_NAVIGATOR_TRUNCATE', '0')
+                if is_truthy(should_truncate):
+                    self.history = self.history[:self.cursor+1]
             self._append(new)
             self.cursor = len(self.history) - 1
 


### PR DESCRIPTION
When the user manually changes directory to a directory that was already in history adjacent to the cursor, this is now treated as a prev/next motion.

Example:
```fish
  ❯           # new shell
  ❯ cd BASE   # history: [~, ~/BASE]             []
  ❯ cd sub    # history: [~, ~/BASE, ~/BASE/sub] []
  ❯ cd ..     # history: [~, ~/BASE]             [~/BASE/sub]
```

Additionally, when the user is in the middle of history traversal (with the cursor not pointing at the last history element), history will be truncated when they go to an entirely new directory now.

Example:
```fish
  ❯           # new shell
  ❯ cd BASE   # history: [~, ~/BASE]             []
  ❯ cd sub    # history: [~, ~/BASE, ~/BASE/sub] []
  ❯ prevd     # history: [~, ~/BASE]             [~/BASE/sub]
  ❯ cd /tmp   # history: [~, ~/BASE, /tmp]       []
  ❯ prevd     # history: [~, ~/BASE]             [/tmp]
```

The previous behavior kept ~/BASE/sub in history, so invoking `prevd` after `cd /tmp` was "returning" to ~/BASE/sub instead of the expected ~/BASE.